### PR TITLE
Add Remix Support

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from pydub import AudioSegment
 from pydub.silence import detect_silence
 from audio_utils.separator import separate_audio
+from audio_utils.remix import handle_remix
 from fastapi.middleware.cors import CORSMiddleware
 import os
 from fastapi.staticfiles import StaticFiles
@@ -11,7 +12,7 @@ from llm_backend.chat_manager import session_manager
 import openai
 from openai.types.chat import ChatCompletionUserMessageParam, ChatCompletionAssistantMessageParam, \
     ChatCompletionSystemMessageParam
-from llm_backend.interpreter import interpret_prompt
+from llm_backend.interpreter import extract_stem_list, classify_prompt
 from models.chat_request import ChatRequest
 from api.upload import router as upload_router
 from models.reset_request import ResetRequest
@@ -35,83 +36,69 @@ app.mount("/downloads", StaticFiles(directory="separated"), name="downloads")
 
 @app.post("/chat")
 def chat(request: ChatRequest):
-    """
-        Main chat endpoint handling conversational flow and orchestration.
-
-        - Logs user message and maintains session history.
-        - Uses LLM to interpret user intent.
-        - If the message implies a stem separation request and a file is uploaded:
-            - Calls separation logic and returns downloadable audio stems.
-            - Crafts a helpful assistant message confirming stem extraction.
-        - Otherwise, responds with natural chat-style LLM response.
-    """
+    session_id = request.session_id
     user_message = request.message
-    session_manager.add_message(request.session_id, "user", user_message)
     history = session_manager.get_history(request.session_id)
+    session_manager.add_message(session_id, "user", user_message)
 
-    messages = [
-       ChatCompletionSystemMessageParam(
-           role="system",
-           content=(
-               "You are a music assistant that helps users extract stems from uploaded audio. "
-               "Respond naturally. If stems were separated, confirm and provide file names."
-           )
-       )
-   ] + [
-       ChatCompletionUserMessageParam(**m) if m["role"] == "user"
-       else ChatCompletionAssistantMessageParam(**m)
-       for m in history
-   ]
+    intent = classify_prompt(user_message)
 
-    selected_stems = interpret_prompt(request.message)
-    audio_path = session_manager.get_file(request.session_id)
-    separated = []
-    silent_stems = []
+    audio_path = session_manager.get_file(session_id)
 
-    if audio_path and selected_stems:
-        outputs = separate_audio(audio_path, selected_stems)
-        for stem_name, stem_tensor in outputs.items():
-            if stem_tensor.ndim == 3:
-                stem_tensor = stem_tensor[0]
-            elif stem_tensor.ndim == 1:
-                stem_tensor = stem_tensor.unsqueeze(0)
+    # Stem separation flow
+    if intent["type"] == "separation":
+        selected_stems = intent.get("stems", [])
+        separated = []
+        silent_stems = []
 
-            uid = uuid.uuid4().hex[:6]
-            base = os.path.splitext(os.path.basename(audio_path))[0]
-            output_name = f"{base}_{stem_name}_{uid}.wav"
-            output_path = f"separated/{output_name}"
-            torchaudio.save(output_path, stem_tensor, 44100) #this
-            audio = AudioSegment.from_file(output_path, format="wav")
+        if audio_path and selected_stems:
+            outputs = separate_audio(audio_path, selected_stems) #are we sure we have audio path?
+            for stem_name, stem_tensor in outputs.items():
+                if stem_tensor.ndim == 3:
+                    stem_tensor = stem_tensor[0]
+                elif stem_tensor.ndim == 1:
+                    stem_tensor = stem_tensor.unsqueeze(0)
 
-            # Detect silent ranges (start_ms, end_ms) where silence lasts longer than 1000 ms and is below -40 dBFS
-            silent_ranges = detect_silence(audio, min_silence_len=1000, silence_thresh=-40)
+                uid = uuid.uuid4().hex[:6]
+                base = os.path.splitext(os.path.basename(audio_path))[0]
+                output_name = f"{base}_{stem_name}_{uid}.wav"
+                output_path = f"separated/{output_name}"
+                torchaudio.save(output_path, stem_tensor, 44100)
+                audio = AudioSegment.from_file(output_path, format="wav")
 
-            # Check if the entire audio is silent
-            is_fully_silent = sum(end - start for start, end in silent_ranges) >= len(audio)
-            if is_fully_silent:
-                silent_stems.append(stem_name)
-            else:
-                url = f"/downloads/{output_name}"
-                separated.append({"name": stem_name, "file_url": url})
+                silent_ranges = detect_silence(audio, min_silence_len=1000, silence_thresh=-40)
+                is_fully_silent = sum(end - start for start, end in silent_ranges) >= len(audio)
 
-        reply = f"✅ Separated stems: {', '.join(s['name'] for s in separated)}. You can download them now."
-        if silent_stems:
-            reply += f" ℹ️ Note: The following stems were detected as silent and not included: {', '.join(silent_stems)}."
+                if is_fully_silent:
+                    silent_stems.append(stem_name)
+                else:
+                    url = f"/downloads/{output_name}"
+                    separated.append({"name": stem_name, "file_url": url})
+
+            reply = f"✅ Separated stems: {', '.join(s['name'] for s in separated)}. You can download them now."
+            if silent_stems:
+                reply += f" ℹ️ Note: The following stems were detected as silent and not included: {', '.join(silent_stems)}."
+        else:
+            reply = "⚠️ No audio file or no valid stems selected."
+        result = {"reply": reply, "stems": separated}
+
+    # Remix flow
+    elif intent["type"] == "remix":
+        result = handle_remix(intent, session_id)
+
+    # Fallback
     else:
-        chat_response = client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=messages,
-            temperature=0,
-        )
-        reply = chat_response.choices[0].message.content
+        result = {
+            "reply": "Sorry, I didn't understand your request. Try asking to extract or remix specific stems."
+        }
 
-    session_manager.add_message(request.session_id, "assistant", reply)
-    response = {
-        "reply": reply,
-        "stems": separated,
+    session_manager.add_message(session_id, "assistant", result["reply"])
+    return {
+        "reply": result["reply"],
+        "stems": result.get("stems", []),
+        "remix": result.get("remix"),
         "history": history
     }
-    return response
 
 @app.post("/reset")
 def reset_session(request: ResetRequest):

--- a/audio_utils/remix.py
+++ b/audio_utils/remix.py
@@ -1,0 +1,49 @@
+import soundfile as sf
+import numpy as np
+import torchaudio
+import os
+import uuid
+from audio_utils.separator import separate_audio
+from llm_backend.chat_manager import session_manager
+
+#Manipulation (gain scaling) - with numpy it is possible to do this without manipulating tensors manually
+def handle_remix(intent: dict, session_id: str) -> dict:
+    audio_path = session_manager.get_file(session_id) #retrieves audio file associated with this session
+    if not audio_path:
+        return {"reply": " No audio file found for remixing."}
+
+    #Separate all 4 stems
+    all_stems = ["vocals", "drums", "bass", "other"]
+    outputs = separate_audio(audio_path, all_stems)
+
+    stem_arrays = {} # dictionary to hold NumPy arrays for each stem, and sets the sample rate to 44.1kHz
+    sr = 44100
+
+    for name in all_stems:
+        tensor = outputs[name]
+        if tensor.ndim == 3:
+            tensor = tensor[0]   # shape [1, 2, N] → [2, N] or [1, N] for channels, samples
+        array = tensor.numpy()
+        if array.shape[0] == 1:  # mono to stereo
+            array = np.repeat(array, 2, axis=0) #this way we ensure we have shape [2, samples] and it becomes mixable even if some stems started as mono
+        stem_arrays[name] = array #Stores the processed stereo waveform in the dictionary under its stem name.
+
+    # Step 2: Remix with volume multipliers
+    volumes = intent["volumes"]
+    min_len = min(arr.shape[1] for arr in stem_arrays.values())
+
+    # Truncate and mix
+    mix = sum(
+        np.clip(stem_arrays[name][:, :min_len] * volumes.get(name, 1.0), -1.0, 1.0)
+        for name in all_stems
+    )
+
+    mix = np.clip(mix, -1.0, 1.0)
+    output_name = f"remix_{uuid.uuid4().hex[:6]}.wav"
+    output_path = f"separated/{output_name}"
+    sf.write(output_path, mix.T, sr)  # Note transpose to (samples, channels)
+
+    return {
+        "reply": f"Remix created based on instructions. Download: /downloads/{output_name}",
+        "remix": {"file_url": f"/downloads/{output_name}"}
+    }

--- a/audio_utils/separator.py
+++ b/audio_utils/separator.py
@@ -12,7 +12,7 @@ def separate_audio(filepath: str, selected_stems: list[str]):
     except RuntimeError:
         torchaudio.set_audio_backend("soundfile")
 
-    print("🧠 Resolving file:", Path(filepath).resolve())
+    print("Resolving file:", Path(filepath).resolve())
     assert Path(filepath).exists(), f"File not found: {filepath}"
     wav, sr = torchaudio.load(filepath)
 
@@ -33,15 +33,13 @@ def separate_audio(filepath: str, selected_stems: list[str]):
         resampler = T.Resample(orig_freq=sr, new_freq=44100)
         wav = resampler(wav)
 
-    # Interpret the prompt (e.g., "vocals and drums") -> ['vocals', 'drums']
-    #selected_stems = interpret_prompt(prompt)
 
     if not selected_stems:
         raise ValueError("No valid stems found in prompt. Please specify vocals, drums, bass, or other.")
 
     #Demucs separation
     separated = apply_model(model, wav, device="cpu")  # Shape: [1, 4, 2, T]
-    print(f"Model output shape: {separated.shape}") #1, 4, 2, N if this is not hte case we might need to switch to model = get_model(name="htdemucs")  # known 4-stem model
+    print(f"Model output shape: {separated.shape}")
 
     # Remove batch dim: shape becomes [4, 2, T]
     separated = separated[0]


### PR DESCRIPTION
additions and improvements: 

- Introduced classify_prompt() to detect user intent (separation vs remix)
- Added handle_remix() to scale and mix all stems based on LLM-suggested volumes
- Restored silence detection for stem separation and excluded silent stems from the output
- Cleaned up /chat endpoint to route based on structured intent
- Ensured fallback response for unrecognized prompts and missing audio